### PR TITLE
More PEP-810 compatibility, fix memory leaks and LOAD_ATTR specialization

### DIFF
--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -38,6 +38,7 @@ extern PyObject* _PyDict_GetItemIdWithError(PyObject *dp,
 extern int _PyDict_ContainsId(PyObject *, _Py_Identifier *);
 extern int _PyDict_SetItemId(PyObject *dp, _Py_Identifier *key, PyObject *item);
 extern int _PyDict_DelItemId(PyObject *mp, _Py_Identifier *key);
+extern void _PyDict_ClearKeysVersion(PyObject *mp);
 
 extern int _PyDict_Next(
     PyObject *mp, Py_ssize_t *pos, PyObject **key, PyObject **value, Py_hash_t *hash);

--- a/Include/internal/pycore_lazyimportobject.h
+++ b/Include/internal/pycore_lazyimportobject.h
@@ -13,7 +13,7 @@ PyAPI_DATA(PyTypeObject) PyLazyImport_Type;
 
 typedef struct {
     PyObject_HEAD
-    PyObject *lz_import_func;
+    PyObject *lz_builtins;
     PyObject *lz_from;
     PyObject *lz_attr;
     /* Frame information for the original import location */

--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -58,6 +58,8 @@ extern Py_ssize_t _PyModule_GetFilenameUTF8(
 PyObject* _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress);
 PyObject* _Py_module_getattro(PyObject *m, PyObject *name);
 
+PyAPI_FUNC(int) _PyModule_ReplaceLazyValue(PyObject *dict, PyObject *name, PyObject *value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -59,7 +59,7 @@ _unpack_uint32 = _bootstrap_external._unpack_uint32
 
 from ._bootstrap import __import__
 
-from _imp import lazy_import, set_lazy_imports
+from _imp import set_lazy_imports
 
 
 def invalidate_caches():

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2790,7 +2790,7 @@ class LazyImportTests(unittest.TestCase):
 
         g = test.test_import.data.lazy_imports.pkg.c.get_globals()
         self.assertEqual(type(g["x"]), int)
-        self.assertEqual(type(g["b"]), importlib.lazy_import)
+        self.assertEqual(type(g["b"]), types.LazyImportType)
 
 class TestSinglePhaseSnapshot(ModuleSnapshot):
     """A representation of a single-phase init module for testing.

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_descrobject.h"   // _PyMethodWrapper_Type
+#include "pycore_lazyimportobject.h" // PyLazyImport_Type
 #include "pycore_namespace.h"     // _PyNamespace_Type
 #include "pycore_object.h"        // _PyNone_Type, _PyNotImplemented_Type
 #include "pycore_unionobject.h"   // _PyUnion_Type
@@ -35,6 +36,7 @@ _types_exec(PyObject *m)
     EXPORT_STATIC_TYPE("GetSetDescriptorType", PyGetSetDescr_Type);
     // LambdaType is the same as FunctionType
     EXPORT_STATIC_TYPE("LambdaType", PyFunction_Type);
+    EXPORT_STATIC_TYPE("LazyImportType", PyLazyImport_Type);
     EXPORT_STATIC_TYPE("MappingProxyType", PyDictProxy_Type);
     EXPORT_STATIC_TYPE("MemberDescriptorType", PyMemberDescr_Type);
     EXPORT_STATIC_TYPE("MethodDescriptorType", PyMethodDescr_Type);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4719,6 +4719,14 @@ sizeof_lock_held(PyDictObject *mp)
     return (Py_ssize_t)res;
 }
 
+void
+_PyDict_ClearKeysVersion(PyObject *mp)
+{
+    ASSERT_DICT_LOCKED(mp);
+
+    FT_ATOMIC_STORE_UINT32_RELAXED(((PyDictObject *)mp)->ma_keys->dk_version, 0);
+}
+
 Py_ssize_t
 _PyDict_SizeOf(PyDictObject *mp)
 {

--- a/Objects/lazyimportobject.c
+++ b/Objects/lazyimportobject.c
@@ -8,7 +8,7 @@
 #include "pycore_interpframe.h"
 
 PyObject *
-_PyLazyImport_New(PyObject *import_func, PyObject *from, PyObject *attr)
+_PyLazyImport_New(PyObject *builtins, PyObject *from, PyObject *attr)
 {
     PyLazyImportObject *m;
     if (!from || !PyUnicode_Check(from)) {
@@ -23,8 +23,8 @@ _PyLazyImport_New(PyObject *import_func, PyObject *from, PyObject *attr)
     if (m == NULL) {
         return NULL;
     }
-    Py_XINCREF(import_func);
-    m->lz_import_func = import_func;
+    Py_XINCREF(builtins);
+    m->lz_builtins = builtins;
     Py_INCREF(from);
     m->lz_from = from;
     Py_XINCREF(attr);
@@ -52,7 +52,7 @@ static void
 lazy_import_dealloc(PyLazyImportObject *m)
 {
     PyObject_GC_UnTrack(m);
-    Py_XDECREF(m->lz_import_func);
+    Py_XDECREF(m->lz_builtins);
     Py_XDECREF(m->lz_from);
     Py_XDECREF(m->lz_attr);
     Py_XDECREF(m->lz_code);
@@ -88,7 +88,7 @@ lazy_import_repr(PyLazyImportObject *m)
 static int
 lazy_import_traverse(PyLazyImportObject *m, visitproc visit, void *arg)
 {
-    Py_VISIT(m->lz_import_func);
+    Py_VISIT(m->lz_builtins);
     Py_VISIT(m->lz_from);
     Py_VISIT(m->lz_attr);
     Py_VISIT(m->lz_code);
@@ -98,7 +98,7 @@ lazy_import_traverse(PyLazyImportObject *m, visitproc visit, void *arg)
 static int
 lazy_import_clear(PyLazyImportObject *m)
 {
-    Py_CLEAR(m->lz_import_func);
+    Py_CLEAR(m->lz_builtins);
     Py_CLEAR(m->lz_from);
     Py_CLEAR(m->lz_attr);
     Py_CLEAR(m->lz_code);

--- a/Objects/lazyimportobject.c
+++ b/Objects/lazyimportobject.c
@@ -144,8 +144,8 @@ static PyMethodDef lazy_methods[] = {
 
 PyTypeObject PyLazyImport_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "lazy_import",                              /* tp_name */
-    sizeof(PyLazyImportObject),                       /* tp_basicsize */
+    "LazyImport",                               /* tp_name */
+    sizeof(PyLazyImportObject),                 /* tp_basicsize */
     0,                                          /* tp_itemsize */
     (destructor)lazy_import_dealloc,            /* tp_dealloc */
     0,                                          /* tp_print */

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2461,17 +2461,18 @@
             if (PyLazyImport_CheckExact(v_o)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, v_o);
-                stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (l_v != NULL && PyDict_SetItem(GLOBALS(), name, l_v) < 0) {
-                    JUMP_TO_LABEL(error);
-                }
-                _PyFrame_SetStackPointer(frame, stack_pointer);
                 Py_DECREF(v_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                v_o = l_v;
-                if (v_o == NULL) {
+                if (l_v == NULL) {
                     JUMP_TO_ERROR();
                 }
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int err = _PyModule_ReplaceLazyValue(GLOBALS(), name, l_v);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (err < 0) {
+                    JUMP_TO_LABEL(error);
+                }
+                v_o = l_v;
             }
             v = PyStackRef_FromPyObjectSteal(v_o);
             stack_pointer[0] = v;
@@ -2495,18 +2496,21 @@
             if (PyLazyImport_CheckExact(res_o)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyObject *l_v = _PyImport_LoadLazyImportTstate(tstate, res_o);
-                stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (l_v != NULL && PyDict_SetItem(GLOBALS(), name, l_v) < 0) {
-                    JUMP_TO_LABEL(error);
-                }
-                res_o = l_v;
-                _PyFrame_SetStackPointer(frame, stack_pointer);
                 PyStackRef_CLOSE(res[0]);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (res_o == NULL) {
+                if (l_v == NULL) {
                     JUMP_TO_ERROR();
                 }
-                *res = PyStackRef_FromPyObjectSteal(res_o);
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int err = _PyModule_ReplaceLazyValue(GLOBALS(), name, l_v);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (err < 0) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    Py_DECREF(l_v);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                    JUMP_TO_LABEL(error);
+                }
+                *res = PyStackRef_FromPyObjectSteal(l_v);
             }
             stack_pointer += 1;
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/import.c
+++ b/Python/import.c
@@ -5377,11 +5377,6 @@ imp_module_exec(PyObject *module)
         return -1;
     }
 
-    if (PyModule_AddObjectRef(module, "lazy_import",
-                              (PyObject *)&PyLazyImport_Type) < 0) {
-        return -1;
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
Expose `LazyImportType` from the types module
Make __import__ be looked up at reification type
Fix memory leaks and specialization with LOAD_ATTR