### PR TITLE
skip linter on test data files

### DIFF
--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -13,6 +13,7 @@ extend-exclude = [
     # New grammar constructions may not yet be recognized by Ruff,
     # and tests re-use the same names as only the grammar is being checked.
     "test_grammar.py",
+    "test_import/data/lazy_imports/*.py",
 ]
 
 [per-file-target-version]


### PR DESCRIPTION
I think the glob pattern[^1] here also includes nested directories because it's based on the glob of Rust[^2] and not the glob of POSIX where `/` is treated as a separator. I don't know whether this will be sufficient though and I'm not on my dev session so feel free to amend this PR if you think the checks are not sufficient.

[^1]: https://docs.astral.sh/ruff/settings/#extend-exclude
[^2]: https://docs.rs/globset/latest/globset/#syntax
