### PR TITLE
Fix more cases where `lazy` is not highlighted in repl

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -276,7 +276,11 @@ def is_soft_keyword_used(*tokens: TI | None) -> bool:
             TI(T.NAME, string=s)
         ):
             return not keyword.iskeyword(s)
-        case (None | TI(T.NEWLINE) | TI(T.INDENT) | TI(T.DEDENT), TI(string="lazy"), TI(string="import") | TI(string="from")):
+        case (
+            None | TI(T.NEWLINE) | TI(T.INDENT) | TI(T.DEDENT) | TI(string=":" | ";"),
+            TI(string="lazy"),
+            TI(string="import") | TI(string="from")
+        ):
             return True
         case _:
             return False

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -96,7 +96,9 @@ class TestUtils(TestCase):
             ("list", [("list", "builtin")]),
             ("    \n dict", [("dict", "builtin")]),
             ("    lazy import", [("lazy", "soft_keyword"), ("import", "keyword")]),
-            ("lazy from cool_people import pablo", [('lazy', 'soft_keyword'), ('from', 'keyword'), ('import', 'keyword')])
+            ("lazy from cool_people import pablo", [('lazy', 'soft_keyword'), ('from', 'keyword'), ('import', 'keyword')]),
+            ("if sad: lazy import happy", [("if", "keyword"), (":", "op"), ("lazy", "soft_keyword"), ("import", "keyword")]),
+            ("pass; lazy import z", [("pass", "keyword"), (';', 'op'), ("lazy", "soft_keyword"), ("import", "keyword")])
         ]
         for code, expected_highlights in cases:
             with self.subTest(code=code):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Apologies @pablogsal for not getting these in the previous fix.