### PR TITLE
Reflow and reformat to stick to line length limits.

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -916,9 +916,11 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    Returns the current lazy imports mode as a string.
 
-   * ``"normal"``: Only imports explicitly marked with the ``lazy`` keyword are lazy
+   * ``"normal"``: Only imports explicitly marked with the ``lazy`` keyword
+     are lazy
    * ``"all"``: All top-level imports are potentially lazy
-   * ``"none"``: All lazy imports are suppressed (even explicitly marked ones)
+   * ``"none"``: All lazy imports are suppressed (even explicitly marked
+     ones)
 
    See also :func:`set_lazy_imports` and :pep:`810`.
 
@@ -927,23 +929,25 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
 .. function:: get_lazy_imports_filter()
 
-   Returns the current lazy imports filter function, or ``None`` if no filter
-   is set.
+   Returns the current lazy imports filter function, or ``None`` if no
+   filter is set.
 
-   The filter function is called for every potentially lazy import to determine
-   whether it should actually be lazy. See :func:`set_lazy_imports_filter` for
-   details on the filter function signature.
+   The filter function is called for every potentially lazy import to
+   determine whether it should actually be lazy. See
+   :func:`set_lazy_imports_filter` for details on the filter function
+   signature.
 
    .. versionadded:: next
 
 
 .. function:: get_lazy_modules()
 
-   Returns a set of fully-qualified module names that have been lazily imported.
-   This is primarily useful for diagnostics and introspection.
+   Returns a set of fully-qualified module names that have been
+   lazilyimported. This is primarily useful for diagnostics and
+   introspection.
 
-   Note that modules are removed from this set when they are reified (actually
-   loaded on first use).
+   Note that modules are removed from this set when they are reified
+   (actually loaded on first use).
 
    .. versionadded:: next
 
@@ -1759,16 +1763,19 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
 .. function:: set_lazy_imports(mode)
 
-   Sets the global lazy imports mode. The *mode* parameter must be one of the
-   following strings:
+   Sets the global lazy imports mode. The *mode* parameter must be one of
+   the following strings:
 
-   * ``"normal"``: Only imports explicitly marked with the ``lazy`` keyword are lazy
+   * ``"normal"``: Only imports explicitly marked with the ``lazy`` keyword
+     are lazy
    * ``"all"``: All top-level imports become potentially lazy
-   * ``"none"``: All lazy imports are suppressed (even explicitly marked ones)
+   * ``"none"``: All lazy imports are suppressed (even explicitly marked
+     ones)
 
-   This function is intended for advanced users who need to control lazy imports
-   across their entire application. Library developers should generally not use
-   this function as it affects the runtime execution of applications.
+   This function is intended for advanced users who need to control lazy
+   imports across their entire application. Library developers should
+   generally not use this function as it affects the runtime execution of
+   applications.
 
    In addition to the mode, lazy imports can be controlled via the filter
    provided by :func:`set_lazy_imports_filter`.
@@ -1783,8 +1790,9 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    Sets the lazy imports filter callback. The *filter* parameter must be a
    callable or ``None`` to clear the filter.
 
-   The filter function is called for every potentially lazy import to determine
-   whether it should actually be lazy. It must have the following signature::
+   The filter function is called for every potentially lazy import to
+   determine whether it should actually be lazy. It must have the following
+   signature::
 
       def filter(importing_module: str, imported_module: str,
                  fromlist: tuple[str, ...] | None) -> bool

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -86,12 +86,12 @@ New features
 :pep:`810`: Explicit lazy imports
 ---------------------------------
 
-Large Python applications often suffer from slow startup times. A significant
-contributor to this problem is the import system: when a module is imported,
-Python must locate the file, read it from disk, compile it to bytecode, and
-execute all top-level code. For applications with deep dependency trees, this
-process can take seconds, even when most of the imported code is never actually
-used during a particular run.
+Large Python applications often suffer from slow startup times. A
+significant contributor to this problem is the import system: when a module
+is imported, Python must locate the file, read it from disk, compile it to
+bytecode, and execute all top-level code. For applications with deep
+dependency trees, this process can take seconds, even when most of the
+imported code is never actually used during a particular run.
 
 Developers have worked around this by moving imports inside functions, using
 :mod:`importlib` to load modules on demand, or restructuring code to avoid
@@ -99,16 +99,18 @@ unnecessary dependencies. These approaches work but make code harder to read
 and maintain, scatter import statements throughout the codebase, and require
 discipline to apply consistently.
 
-Python now provides a cleaner solution through explicit :keyword:`lazy` imports
-using the new ``lazy`` soft keyword. When you mark an import as lazy, Python
-defers the actual module loading until the imported name is first used. This
-gives you the organizational benefits of declaring all imports at the top of
-the file while only paying the loading cost for modules you actually use.
+Python now provides a cleaner solution through explicit :keyword:`lazy`
+imports using the new ``lazy`` soft keyword. When you mark an import as
+lazy, Python defers the actual module loading until the imported name is
+first used. This gives you the organizational benefits of declaring all
+imports at the top of the file while only paying the loading cost for
+modules you actually use.
 
-The ``lazy`` keyword works with both ``import`` and ``from ... import`` statements.
-When you write ``lazy import heavy_module``, Python does not immediately load the
-module. Instead, it creates a lightweight proxy object. The actual module loading
-happens transparently when you first access the name:
+The ``lazy`` keyword works with both ``import`` and ``from ... import``
+statements. When you write ``lazy import heavy_module``, Python does not
+immediately load the module. Instead, it creates a lightweight proxy object.
+The actual module loading happens transparently when you first access the
+name:
 
 .. code-block:: python
 
@@ -120,54 +122,59 @@ happens transparently when you first access the name:
    data = json.loads('{"key": "value"}')  # json gets loads here
    now = datetime()  # datetime loads here
 
-This mechanism is particularly useful for applications that import many modules
-at the top level but may only use a subset of them in any given run. The deferred
-loading reduces startup latency without requiring code restructuring or conditional
-imports scattered throughout the codebase.
+This mechanism is particularly useful for applications that import many
+modules at the top level but may only use a subset of them in any given run.
+The deferred loading reduces startup latency without requiring code
+restructuring or conditional imports scattered throughout the codebase.
 
-In the case where loading a lazily imported module fails (for example, if the
-module does not exist), Python raises the exception at the point of first use
-rather than at import time. The associated traceback includes both the location
-where the name was accessed and the original import statement, making it
-straightforward to diagnose & debug the failure.
+In the case where loading a lazily imported module fails (for example, if
+the module does not exist), Python raises the exception at the point of
+first use rather than at import time. The associated traceback includes both
+the location where the name was accessed and the original import statement,
+making it straightforward to diagnose & debug the failure.
 
-For cases where you want to enable lazy loading globally without modifying source
-code, Python provides the :option:`-X lazy_imports <-X>` command-line option and
-the :envvar:`PYTHON_LAZY_IMPORTS` environment variable. Both accept three values:
-``all`` makes all imports lazy by default, ``none`` disables lazy imports entirely
-(even explicit ``lazy`` statements become eager), and ``normal`` (the default)
-respects the ``lazy`` keyword in source code. The :func:`sys.set_lazy_imports` and
-:func:`sys.get_lazy_imports` functions allow changing and querying this mode at
-runtime.
+For cases where you want to enable lazy loading globally without modifying
+source code, Python provides the :option:`-X lazy_imports <-X>` command-line
+option and the :envvar:`PYTHON_LAZY_IMPORTS` environment variable. Both
+accept three values: ``all`` makes all imports lazy by default, ``none``
+disables lazy imports entirely (even explicit ``lazy`` statements become
+eager), and ``normal`` (the default) respects the ``lazy`` keyword in source
+code. The :func:`sys.set_lazy_imports` and :func:`sys.get_lazy_imports`
+functions allow changing and querying this mode at runtime.
 
-For more selective control, :func:`sys.set_lazy_imports_filter` accepts a callable
-that determines whether a specific module should be loaded lazily. The filter
-receives three arguments: the importing module's name (or ``None``), the imported
-module's name, and the fromlist (or ``None`` for regular imports). It should
-return ``True`` to allow the import to be lazy, or ``False`` to force eager loading.
-This allows patterns like making only your own application's modules lazy while
-keeping third-party dependencies eager:
+For more selective control, :func:`sys.set_lazy_imports_filter` accepts a
+callable that determines whether a specific module should be loaded lazily.
+The filter receives three arguments: the importing module's name (or
+``None``), the imported module's name, and the fromlist (or ``None`` for
+regular imports). It should return ``True`` to allow the import to be lazy,
+or ``False`` to force eager loading. This allows patterns like making only
+your own application's modules lazy while keeping third-party dependencies
+eager:
 
 .. code-block:: python
 
    import sys
 
-   sys.set_lazy_imports_filter(lambda importing, imported, fromlist: imported.startswith("myapp."))
+   def myapp_filter(importing, imported, fromlist):
+       return imported.startswith("myapp.")
+   sys.set_lazy_imports_filter(myapp_filter)
    sys.set_lazy_imports("all")
 
    import myapp.slow_module  # lazy (matches filter)
    import json               # eager (does not match filter)
 
 For debugging and introspection, :func:`sys.get_lazy_modules` returns a set
-containing the names of all modules that have been lazily imported but not yet
-loaded. The proxy type itself is available as :data:`types.LazyImportType` for
-code that needs to detect lazy imports programmatically.
+containing the names of all modules that have been lazily imported but not
+yet loaded. The proxy type itself is available as
+:data:`types.LazyImportType` for code that needs to detect lazy imports
+programmatically.
 
 There are some restrictions on where the ``lazy`` keyword can be used. Lazy
-imports are only permitted at module scope; using ``lazy`` inside a function,
-class body, or ``try``/``except``/``finally`` block raises a :exc:`SyntaxError`.
-Neither star imports nor future imports can be lazy (``lazy from module import *``
-and ``lazy from __future__ import ...`` both raise :exc:`SyntaxError`).
+imports are only permitted at module scope; using ``lazy`` inside a
+function, class body, or ``try``/``except``/``finally`` block raises a
+:exc:`SyntaxError`. Neither star imports nor future imports can be lazy
+(``lazy from module import *`` and ``lazy from __future__ import ...`` both
+raise :exc:`SyntaxError`).
 
 .. seealso:: :pep:`810` for the full specification and rationale.
 

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -311,14 +311,19 @@ PyAPI_FUNC(void) _PyEval_FormatExcCheckArg(PyThreadState *tstate, PyObject *exc,
 PyAPI_FUNC(void) _PyEval_FormatExcUnbound(PyThreadState *tstate, PyCodeObject *co, int oparg);
 PyAPI_FUNC(void) _PyEval_FormatKwargsError(PyThreadState *tstate, PyObject *func, PyObject *kwargs);
 PyAPI_FUNC(PyObject *) _PyEval_ImportFrom(PyThreadState *, PyObject *, PyObject *);
-PyAPI_FUNC(PyObject *) _PyEval_LazyImportName(PyThreadState *tstate, PyObject *builtins, PyObject *globals,
-            PyObject *locals, PyObject *name, PyObject *fromlist, PyObject *level, int lazy);
-PyAPI_FUNC(PyObject *) _PyEval_LazyImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name);
-PyAPI_FUNC(PyObject *) _PyEval_ImportName(PyThreadState *tstate, PyObject *builtins, PyObject *globals, PyObject *locals,
-            PyObject *name, PyObject *fromlist, PyObject *level);
-PyObject *
-_PyEval_ImportNameWithImport(PyThreadState *tstate, PyObject *import_func, PyObject *globals, PyObject *locals,
-                             PyObject *name, PyObject *fromlist, PyObject *level);
+
+PyAPI_FUNC(PyObject *) _PyEval_LazyImportName(
+    PyThreadState *tstate, PyObject *builtins, PyObject *globals,
+    PyObject *locals, PyObject *name, PyObject *fromlist, PyObject *level,
+    int lazy);
+PyAPI_FUNC(PyObject *) _PyEval_LazyImportFrom(
+    PyThreadState *tstate, PyObject *v, PyObject *name);
+PyAPI_FUNC(PyObject *) _PyEval_ImportName(
+    PyThreadState *tstate, PyObject *builtins, PyObject *globals,
+    PyObject *locals, PyObject *name, PyObject *fromlist, PyObject *level);
+PyObject * _PyEval_ImportNameWithImport(
+    PyThreadState *tstate, PyObject *import_func, PyObject *globals,
+    PyObject *locals, PyObject *name, PyObject *fromlist, PyObject *level);
 PyAPI_FUNC(PyObject *)_PyEval_MatchClass(PyThreadState *tstate, PyObject *subject, PyObject *type, Py_ssize_t nargs, PyObject *kwargs);
 PyAPI_FUNC(PyObject *)_PyEval_MatchKeys(PyThreadState *tstate, PyObject *map, PyObject *keys);
 PyAPI_FUNC(void) _PyEval_MonitorRaise(PyThreadState *tstate, _PyInterpreterFrame *frame, _Py_CODEUNIT *instr);

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -40,7 +40,8 @@ extern int _PyDict_Contains_KnownHash(PyObject *, PyObject *, Py_hash_t);
 extern PyObject* _PyDict_GetItemIdWithError(PyObject *dp,
                                             _Py_Identifier *key);
 extern int _PyDict_ContainsId(PyObject *, _Py_Identifier *);
-extern int _PyDict_SetItemId(PyObject *dp, _Py_Identifier *key, PyObject *item);
+extern int _PyDict_SetItemId(PyObject *dp, _Py_Identifier *key,
+                             PyObject *item);
 extern int _PyDict_DelItemId(PyObject *mp, _Py_Identifier *key);
 extern void _PyDict_ClearKeysVersion(PyObject *mp);
 

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -32,17 +32,16 @@ extern int _PyImport_FixupBuiltin(
     PyObject *modules
     );
 
-extern PyObject *
-_PyImport_ResolveName(PyThreadState *tstate, PyObject *name, PyObject *globals, int level);
-extern PyObject *
-_PyImport_GetAbsName(PyThreadState *tstate, PyObject *name, PyObject *globals, int level);
+extern PyObject * _PyImport_ResolveName(
+    PyThreadState *tstate, PyObject *name, PyObject *globals, int level);
+extern PyObject * _PyImport_GetAbsName(
+    PyThreadState *tstate, PyObject *name, PyObject *globals, int level);
 // Symbol is exported for the JIT on Windows builds.
-PyAPI_FUNC(PyObject *)
-_PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import);
-extern PyObject *
-_PyImport_LazyImportModuleLevelObject(PyThreadState *tstate, PyObject *name, PyObject *builtins, PyObject *globals,
-                                      PyObject *locals, PyObject *fromlist,
-                                      int level);
+PyAPI_FUNC(PyObject *) _PyImport_LoadLazyImportTstate(
+    PyThreadState *tstate, PyObject *lazy_import);
+extern PyObject * _PyImport_LazyImportModuleLevelObject(
+    PyThreadState *tstate, PyObject *name, PyObject *builtins,
+    PyObject *globals, PyObject *locals, PyObject *fromlist, int level);
 
 
 #ifdef HAVE_DLOPEN
@@ -82,7 +81,8 @@ extern void _PyImport_ClearModules(PyInterpreterState *interp);
 
 extern void _PyImport_ClearModulesByIndex(PyInterpreterState *interp);
 
-extern PyObject * _PyImport_InitLazyModules(PyInterpreterState *interp);
+extern PyObject * _PyImport_InitLazyModules(
+    PyInterpreterState *interp);
 extern void _PyImport_ClearLazyModules(PyInterpreterState *interp);
 
 extern int _PyImport_InitDefaultImportFunc(PyInterpreterState *interp);

--- a/Include/internal/pycore_lazyimportobject.h
+++ b/Include/internal/pycore_lazyimportobject.h
@@ -1,6 +1,4 @@
-/* File added for Lazy Imports */
-
-/* Lazy object interface */
+// Lazy object interface.
 
 #ifndef Py_INTERNAL_LAZYIMPORTOBJECT_H
 #define Py_INTERNAL_LAZYIMPORTOBJECT_H
@@ -21,16 +19,17 @@ typedef struct {
     PyObject *lz_builtins;
     PyObject *lz_from;
     PyObject *lz_attr;
-    /* Frame information for the original import location */
-    PyCodeObject *lz_code;     /* code object where the lazy import was created */
-    int lz_instr_offset;       /* instruction offset where the lazy import was created */
+    // Frame information for the original import location.
+    PyCodeObject *lz_code;     // Code object where the lazy import was created.
+    int lz_instr_offset;       // Instruction offset where the lazy import was created.
 } PyLazyImportObject;
 
 
 PyAPI_FUNC(PyObject *) _PyLazyImport_GetName(PyObject *lazy_import);
-PyAPI_FUNC(PyObject *) _PyLazyImport_New(PyObject *import_func, PyObject *from, PyObject *attr);
+PyAPI_FUNC(PyObject *) _PyLazyImport_New(
+    PyObject *import_func, PyObject *from, PyObject *attr);
 
 #ifdef __cplusplus
 }
 #endif
-#endif /* !Py_INTERNAL_LAZYIMPORTOBJECT_H */
+#endif // !Py_INTERNAL_LAZYIMPORTOBJECT_H

--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -78,7 +78,8 @@ extern Py_ssize_t _PyModule_GetFilenameUTF8(
 PyObject* _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress);
 PyObject* _Py_module_getattro(PyObject *m, PyObject *name);
 
-PyAPI_FUNC(int) _PyModule_ReplaceLazyValue(PyObject *dict, PyObject *name, PyObject *value);
+PyAPI_FUNC(int) _PyModule_ReplaceLazyValue(
+    PyObject *dict, PyObject *name, PyObject *value);
 
 #ifdef __cplusplus
 }

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -1019,7 +1019,8 @@ def _find_imports(co):
                 (level_op[0] in hasconst or level_op[0] == LOAD_SMALL_INT)):
                 level = _get_const_value(level_op[0], level_op[1], consts)
                 fromlist = _get_const_value(from_op[0], from_op[1], consts)
-                # IMPORT_NAME encodes lazy/eager flags in bits 0-1, name index in bits 2+
+                # IMPORT_NAME encodes lazy/eager flags in bits 0-1,
+                # name index in bits 2+.
                 yield (names[oparg >> 2], level, fromlist)
 
 def _find_store_names(co):

--- a/Lib/idlelib/idle_test/test_colorizer.py
+++ b/Lib/idlelib/idle_test/test_colorizer.py
@@ -545,9 +545,11 @@ class ColorDelegatorTest(unittest.TestCase):
     def test_lazy_soft_keyword(self):
         # lazy followed by import
         self._assert_highlighting('lazy import foo',
-                                  {'KEYWORD': [('1.0', '1.4'), ('1.5', '1.11')]})
+                                  {'KEYWORD': [('1.0', '1.4'),
+                                               ('1.5', '1.11')]})
         self._assert_highlighting('    lazy import foo',
-                                  {'KEYWORD': [('1.4', '1.8'), ('1.9', '1.15')]})
+                                  {'KEYWORD': [('1.4', '1.8'),
+                                               ('1.9', '1.15')]})
 
         # lazy followed by from
         self._assert_highlighting('lazy from foo import bar',

--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -192,7 +192,8 @@ class Completer:
 
                     if (isinstance(thisobject, types.ModuleType)
                         and
-                        isinstance(thisobject.__dict__.get(word), types.LazyImportType)
+                        isinstance(thisobject.__dict__.get(word),
+                                   types.LazyImportType)
                     ):
                         value = thisobject.__dict__.get(word)
                     else:

--- a/Lib/test/test_import/data/lazy_imports/dunder_lazy_import_builtins.py
+++ b/Lib/test/test_import/data/lazy_imports/dunder_lazy_import_builtins.py
@@ -9,5 +9,6 @@ new_globals["__builtins__"] = {
     "__import__": myimport,
 }
 basic2 = 42
-basic = __lazy_import__("test.test_import.data.lazy_imports.basic2", globals=new_globals)
+basic = __lazy_import__("test.test_import.data.lazy_imports.basic2",
+                        globals=new_globals)
 basic

--- a/Lib/test/test_import/data/lazy_imports/dunder_lazy_import_used.py
+++ b/Lib/test/test_import/data/lazy_imports/dunder_lazy_import_used.py
@@ -1,2 +1,3 @@
-basic = __lazy_import__('test.test_import.data.lazy_imports', fromlist=("basic2", ))
+basic = __lazy_import__('test.test_import.data.lazy_imports',
+                        fromlist=("basic2", ))
 basic

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -95,10 +95,36 @@ class TestUtils(TestCase):
             ("set", [("set", "builtin")]),
             ("list", [("list", "builtin")]),
             ("    \n dict", [("dict", "builtin")]),
-            ("    lazy import", [("lazy", "soft_keyword"), ("import", "keyword")]),
-            ("lazy from cool_people import pablo", [('lazy', 'soft_keyword'), ('from', 'keyword'), ('import', 'keyword')]),
-            ("if sad: lazy import happy", [("if", "keyword"), (":", "op"), ("lazy", "soft_keyword"), ("import", "keyword")]),
-            ("pass; lazy import z", [("pass", "keyword"), (';', 'op'), ("lazy", "soft_keyword"), ("import", "keyword")])
+            (
+                "    lazy import",
+                [("lazy", "soft_keyword"), ("import", "keyword")],
+            ),
+            (
+                "lazy from cool_people import pablo",
+                [
+                    ("lazy", "soft_keyword"),
+                    ("from", "keyword"),
+                    ("import", "keyword"),
+                ],
+            ),
+            (
+                "if sad: lazy import happy",
+                [
+                    ("if", "keyword"),
+                    (":", "op"),
+                    ("lazy", "soft_keyword"),
+                    ("import", "keyword"),
+                ],
+            ),
+            (
+                "pass; lazy import z",
+                [
+                    ("pass", "keyword"),
+                    (";", "op"),
+                    ("lazy", "soft_keyword"),
+                    ("import", "keyword"),
+                ],
+            ),
         ]
         for code, expected_highlights in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -55,10 +55,11 @@ class TypesTests(unittest.TestCase):
             'CoroutineType', 'EllipsisType', 'FrameType', 'FunctionType',
             'FrameLocalsProxyType',
             'GeneratorType', 'GenericAlias', 'GetSetDescriptorType',
-            'LambdaType', 'LazyImportType', 'MappingProxyType', 'MemberDescriptorType',
-            'MethodDescriptorType', 'MethodType', 'MethodWrapperType',
-            'ModuleType', 'NoneType', 'NotImplementedType', 'SimpleNamespace',
-            'TracebackType', 'UnionType', 'WrapperDescriptorType',
+            'LambdaType', 'LazyImportType', 'MappingProxyType',
+            'MemberDescriptorType', 'MethodDescriptorType', 'MethodType',
+            'MethodWrapperType', 'ModuleType', 'NoneType',
+            'NotImplementedType', 'SimpleNamespace', 'TracebackType',
+            'UnionType', 'WrapperDescriptorType',
         }
         self.assertEqual(all_names, set(c_types.__all__))
         self.assertEqual(all_names - c_only_names, set(py_types.__all__))

--- a/Objects/lazyimportobject.c
+++ b/Objects/lazyimportobject.c
@@ -1,4 +1,4 @@
-/* Lazy object implementation */
+// Lazy object implementation.
 
 #include "Python.h"
 #include "pycore_ceval.h"
@@ -23,7 +23,7 @@ _PyLazyImport_New(PyObject *builtins, PyObject *name, PyObject *fromlist)
     }
     else if (!PyUnicode_Check(fromlist) && !PyTuple_Check(fromlist)) {
         PyErr_SetString(PyExc_TypeError,
-                        "lazy_import: fromlist must be None, a string, or a tuple");
+            "lazy_import: fromlist must be None, a string, or a tuple");
         return NULL;
     }
     m = PyObject_GC_New(PyLazyImportObject, &PyLazyImport_Type);
@@ -34,7 +34,7 @@ _PyLazyImport_New(PyObject *builtins, PyObject *name, PyObject *fromlist)
     m->lz_from = Py_NewRef(name);
     m->lz_attr = Py_XNewRef(fromlist);
 
-    /* Capture frame information for the original import location */
+    // Capture frame information for the original import location.
     m->lz_code = NULL;
     m->lz_instr_offset = -1;
 
@@ -43,7 +43,7 @@ _PyLazyImport_New(PyObject *builtins, PyObject *name, PyObject *fromlist)
         PyCodeObject *code = _PyFrame_GetCode(frame);
         if (code != NULL) {
             m->lz_code = (PyCodeObject *)Py_NewRef(code);
-            /* Calculate the instruction offset from the current frame */
+            // Calculate the instruction offset from the current frame.
             m->lz_instr_offset = _PyInterpreterFrame_LASTI(frame);
         }
     }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1270,10 +1270,10 @@ _PyModule_IsPossiblyShadowing(PyObject *origin)
 int
 _PyModule_ReplaceLazyValue(PyObject *dict, PyObject *name, PyObject *value)
 {
-    // The adaptive interpreter uses the dictionary version to return the slot at
-    // a given index from the module. When replacing a value the version number doesn't
-    // change, so we need to atomically clear the version before replacing so that it
-    // doesn't return a lazy value.
+    // The adaptive interpreter uses the dictionary version to return the
+    // slot at a given index from the module. When replacing a value the
+    // version number doesn't change, so we need to atomically clear the
+    // version before replacing so that it doesn't return a lazy value.
     int err;
     Py_BEGIN_CRITICAL_SECTION(dict);
 
@@ -1292,12 +1292,15 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
     attr = _PyObject_GenericGetAttrWithDict((PyObject *)m, name, NULL, suppress);
     if (attr) {
         if (PyLazyImport_CheckExact(attr)) {
-            PyObject *new_value = _PyImport_LoadLazyImportTstate(PyThreadState_GET(), attr);
+            PyObject *new_value = _PyImport_LoadLazyImportTstate(
+                PyThreadState_GET(), attr);
             if (new_value == NULL) {
-                if (suppress && PyErr_ExceptionMatches(PyExc_ImportCycleError)) {
-                    // ImportCycleError is raised when a lazy object tries to import itself.
-                    // In this case, the error should not propagate to the caller and
-                    // instead treated as if the attribute doesn't exist.
+                if (suppress &&
+                    PyErr_ExceptionMatches(PyExc_ImportCycleError)) {
+                    // ImportCycleError is raised when a lazy object tries
+                    // to import itself. In this case, the error should not
+                    // propagate to the caller and instead treated as if the
+                    // attribute doesn't exist.
                     PyErr_Clear();
                 }
                 Py_DECREF(attr);

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1971,12 +1971,14 @@ _PyPegen_concatenate_strings(Parser *p, asdl_expr_seq *strings,
 }
 
 stmt_ty
-_PyPegen_checked_future_import(Parser *p, identifier module, asdl_alias_seq * names, int level,
-                               expr_ty lazy_token, int lineno, int col_offset, int end_lineno, int end_col_offset,
+_PyPegen_checked_future_import(Parser *p, identifier module, asdl_alias_seq * names,
+                               int level, expr_ty lazy_token, int lineno,
+                               int col_offset, int end_lineno, int end_col_offset,
                                PyArena *arena) {
     if (level == 0 && PyUnicode_CompareWithASCIIString(module, "__future__") == 0) {
         if (lazy_token) {
-            RAISE_SYNTAX_ERROR_KNOWN_LOCATION(lazy_token, "lazy from __future__ import is not allowed");
+            RAISE_SYNTAX_ERROR_KNOWN_LOCATION(lazy_token,
+                "lazy from __future__ import is not allowed");
             return NULL;
         }
         for (Py_ssize_t i = 0; i < asdl_seq_LEN(names); i++) {
@@ -1986,7 +1988,8 @@ _PyPegen_checked_future_import(Parser *p, identifier module, asdl_alias_seq * na
             }
         }
     }
-    return _PyAST_ImportFrom(module, names, level, lazy_token ? 1 : 0, lineno, col_offset, end_lineno, end_col_offset, arena);
+    return _PyAST_ImportFrom(module, names, level, lazy_token ? 1 : 0, lineno,
+                             col_offset, end_lineno, end_col_offset, arena);
 }
 
 asdl_stmt_seq*

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -322,21 +322,23 @@ builtin___lazy_import___impl(PyObject *module, PyObject *name,
         return NULL;
     }
     if (builtins == NULL) {
-        PyErr_SetString(PyExc_ValueError, "unable to get builtins for lazy import");
+        PyErr_SetString(PyExc_ValueError,
+                        "unable to get builtins for lazy import");
         return NULL;
     }
     if (PyModule_Check(builtins)) {
         PyObject *builtins_dict = Py_XNewRef(PyModule_GetDict(builtins));
         if (builtins_dict == NULL) {
             Py_DECREF(builtins);
-            PyErr_SetString(PyExc_AttributeError, "builtins module has no dict");
+            PyErr_SetString(PyExc_AttributeError,
+                            "builtins module has no dict");
             return NULL;
         }
         Py_SETREF(builtins, builtins_dict);
     }
 
-    PyObject *res = _PyImport_LazyImportModuleLevelObject(tstate, name, builtins,
-                                                 globals, locals, fromlist, level);
+    PyObject *res = _PyImport_LazyImportModuleLevelObject(
+        tstate, name, builtins, globals, locals, fromlist, level);
     Py_DECREF(builtins);
     return res;
 }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2950,14 +2950,16 @@ dummy_func(
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg >> 2);
             PyObject *res_o;
             if (!(oparg & 0x02)) {
-                res_o = _PyEval_LazyImportName(tstate, BUILTINS(), GLOBALS(), LOCALS(), name,
+                res_o = _PyEval_LazyImportName(tstate, BUILTINS(), GLOBALS(),
+                                LOCALS(), name,
                                 PyStackRef_AsPyObjectBorrow(fromlist),
                                 PyStackRef_AsPyObjectBorrow(level),
                                 oparg & 0x01);
 
             }
             else {
-                res_o = _PyEval_ImportName(tstate, BUILTINS(), GLOBALS(), LOCALS(), name,
+                res_o = _PyEval_ImportName(tstate, BUILTINS(), GLOBALS(),
+                                LOCALS(), name,
                                 PyStackRef_AsPyObjectBorrow(fromlist),
                                 PyStackRef_AsPyObjectBorrow(level));
             }
@@ -2970,10 +2972,12 @@ dummy_func(
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             PyObject *res_o;
             if (PyLazyImport_CheckExact(PyStackRef_AsPyObjectBorrow(from))) {
-                res_o = _PyEval_LazyImportFrom(tstate, PyStackRef_AsPyObjectBorrow(from), name);
+                res_o = _PyEval_LazyImportFrom(
+                    tstate, PyStackRef_AsPyObjectBorrow(from), name);
             }
             else {
-                res_o = _PyEval_ImportFrom(tstate, PyStackRef_AsPyObjectBorrow(from), name);
+                res_o = _PyEval_ImportFrom(
+                    tstate, PyStackRef_AsPyObjectBorrow(from), name);
             }
 
             ERROR_IF(res_o == NULL);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3474,11 +3474,13 @@ _PyEval_SliceIndexNotNone(PyObject *v, Py_ssize_t *pi)
 }
 
 PyObject *
-_PyEval_ImportName(PyThreadState *tstate, PyObject *builtins, PyObject *globals, PyObject *locals,
-            PyObject *name, PyObject *fromlist, PyObject *level)
+_PyEval_ImportName(PyThreadState *tstate, PyObject *builtins,
+            PyObject *globals, PyObject *locals, PyObject *name,
+            PyObject *fromlist, PyObject *level)
 {
     PyObject *import_func;
-    if (PyMapping_GetOptionalItem(builtins, &_Py_ID(__import__), &import_func) < 0) {
+    if (PyMapping_GetOptionalItem(builtins, &_Py_ID(__import__),
+                                  &import_func) < 0) {
         return NULL;
     }
     if (import_func == NULL) {
@@ -3486,13 +3488,15 @@ _PyEval_ImportName(PyThreadState *tstate, PyObject *builtins, PyObject *globals,
         return NULL;
     }
 
-    PyObject *res = _PyEval_ImportNameWithImport(tstate, import_func, globals, locals, name, fromlist, level);
+    PyObject *res = _PyEval_ImportNameWithImport(
+        tstate, import_func, globals, locals, name, fromlist, level);
     Py_DECREF(import_func);
     return res;
 }
 
 PyObject *
-_PyEval_ImportNameWithImport(PyThreadState *tstate, PyObject *import_func, PyObject *globals, PyObject *locals,
+_PyEval_ImportNameWithImport(PyThreadState *tstate, PyObject *import_func,
+                             PyObject *globals, PyObject *locals,
                              PyObject *name, PyObject *fromlist, PyObject *level)
 {
     if (locals == NULL) {
@@ -3529,7 +3533,8 @@ check_lazy_import_compatibility(PyThreadState *tstate, PyObject *globals,
     int res = -1;
 
     if (globals != NULL &&
-        PyMapping_GetOptionalItem(globals, &_Py_ID(__lazy_modules__), &lazy_modules) < 0)
+        PyMapping_GetOptionalItem(globals, &_Py_ID(__lazy_modules__),
+                                  &lazy_modules) < 0)
     {
         return -1;
     }
@@ -3556,9 +3561,9 @@ error:
 }
 
 PyObject *
-_PyEval_LazyImportName(PyThreadState *tstate, PyObject *builtins, PyObject *globals,
-                       PyObject *locals, PyObject *name, PyObject *fromlist, PyObject *level,
-                       int lazy)
+_PyEval_LazyImportName(PyThreadState *tstate, PyObject *builtins,
+                       PyObject *globals, PyObject *locals, PyObject *name,
+                       PyObject *fromlist, PyObject *level, int lazy)
 {
     PyObject *res = NULL;
     // Check if global policy overrides the local syntax
@@ -3582,17 +3587,21 @@ _PyEval_LazyImportName(PyThreadState *tstate, PyObject *builtins, PyObject *glob
     }
 
     if (!lazy) {
-        // Not a lazy import or lazy imports are disabled, fallback to the regular import
-        return _PyEval_ImportName(tstate, builtins, globals, locals, name, fromlist, level);
+        // Not a lazy import or lazy imports are disabled, fallback to the
+        // regular import.
+        return _PyEval_ImportName(tstate, builtins, globals, locals,
+                                  name, fromlist, level);
     }
 
     PyObject *lazy_import_func;
-    if (PyMapping_GetOptionalItem(builtins, &_Py_ID(__lazy_import__), &lazy_import_func) < 0) {
+    if (PyMapping_GetOptionalItem(builtins, &_Py_ID(__lazy_import__),
+                                  &lazy_import_func) < 0) {
         goto error;
     }
     if (lazy_import_func == NULL) {
         assert(!PyErr_Occurred());
-        _PyErr_SetString(tstate, PyExc_ImportError, "__lazy_import__ not found");
+        _PyErr_SetString(tstate, PyExc_ImportError,
+                         "__lazy_import__ not found");
         goto error;
     }
 
@@ -3797,7 +3806,8 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
     PyLazyImportObject *d = (PyLazyImportObject *)v;
     PyObject *mod = PyImport_GetModule(d->lz_from);
     if (mod != NULL) {
-        // Check if the module already has the attribute, if so, resolve it eagerly.
+        // Check if the module already has the attribute, if so, resolve it
+        // eagerly.
         if (PyModule_Check(mod)) {
             PyObject *mod_dict = PyModule_GetDict(mod);
             if (mod_dict != NULL) {
@@ -3816,7 +3826,8 @@ _PyEval_LazyImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
 
     if (d->lz_attr != NULL) {
         if (PyUnicode_Check(d->lz_attr)) {
-            PyObject *from = PyUnicode_FromFormat("%U.%U", d->lz_from, d->lz_attr);
+            PyObject *from = PyUnicode_FromFormat(
+                "%U.%U", d->lz_from, d->lz_attr);
             if (from == NULL) {
                 return NULL;
             }

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -351,8 +351,8 @@ codegen_addop_o(compiler *c, location loc,
 #define LOAD_ZERO_SUPER_METHOD -4
 
 static int
-codegen_addop_name_custom(compiler *c, location loc,
-                   int opcode, PyObject *dict, PyObject *o, int shift, int low)
+codegen_addop_name_custom(compiler *c, location loc, int opcode,
+                          PyObject *dict, PyObject *o, int shift, int low)
 {
     PyObject *mangled = _PyCompile_MaybeMangle(c, o);
     if (!mangled) {
@@ -2856,7 +2856,8 @@ static int
 codegen_validate_lazy_import(compiler *c, location loc)
 {
     if (_PyCompile_ScopeType(c) != COMPILE_SCOPE_MODULE) {
-        return _PyCompile_Error(c, loc, "lazy imports only allowed in module scope");
+        return _PyCompile_Error(
+            c, loc, "lazy imports only allowed in module scope");
     }
 
     return SUCCESS;
@@ -2886,7 +2887,8 @@ codegen_import(compiler *c, stmt_ty s)
             RETURN_IF_ERROR(codegen_validate_lazy_import(c, loc));
             ADDOP_NAME_CUSTOM(c, loc, IMPORT_NAME, alias->name, names, 2, 1);
         } else {
-            if (_PyCompile_InExceptionHandler(c) || _PyCompile_ScopeType(c) != COMPILE_SCOPE_MODULE) {
+            if (_PyCompile_InExceptionHandler(c) ||
+                _PyCompile_ScopeType(c) != COMPILE_SCOPE_MODULE) {
                 // force eager import in try/except block
                 ADDOP_NAME_CUSTOM(c, loc, IMPORT_NAME, alias->name, names, 2, 2);
             } else {

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -318,8 +318,8 @@ The following implementation-specific options are available:\n\
 "\
 -X importtime[=2]: show how long each import takes; use -X importtime=2 to\n\
          log imports of already-loaded modules; also PYTHONPROFILEIMPORTTIME\n\
--X lazy_imports=[all|none|normal]: control global lazy imports; default is normal;\n\
-         also PYTHON_LAZY_IMPORTS\n\
+-X lazy_imports=[all|none|normal]: control global lazy imports;\n\
+         default is normal; also PYTHON_LAZY_IMPORTS\n\
 -X int_max_str_digits=N: limit the size of int<->str conversions;\n\
          0 disables the limit; also PYTHONINTMAXSTRDIGITS\n\
 -X no_debug_ranges: don't include extra location information in code objects;\n\

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1330,8 +1330,8 @@ init_interp_main(PyThreadState *tstate)
         }
     }
 
-    // Initialize lazy imports based on configuration
-    // Do this after site module is imported to avoid circular imports during startup
+    // Initialize lazy imports based on configuration. Do this after site
+    // module is imported to avoid circular imports during startup.
     if (config->lazy_imports != -1) {
         PyImport_LazyImportsMode lazy_mode;
         if (config->lazy_imports == 1) {
@@ -1344,7 +1344,7 @@ init_interp_main(PyThreadState *tstate)
             return _PyStatus_ERR("failed to set lazy imports mode");
         }
     }
-    // If config->lazy_imports == -1, use the default mode (no change needed)
+    // If config->lazy_imports == -1, use the default mode, no change needed.
 
     if (is_main_interp) {
 #ifndef MS_WINDOWS

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1817,28 +1817,30 @@ check_import_from(struct symtable *st, stmt_ty s)
 }
 
 static int
-check_lazy_import_context(struct symtable *st, stmt_ty s, const char* import_type)
+check_lazy_import_context(struct symtable *st, stmt_ty s,
+                          const char* import_type)
 {
-    /* Check if inside try/except block */
+    // Check if inside try/except block.
     if (st->st_cur->ste_in_try_block) {
         PyErr_Format(PyExc_SyntaxError,
-                    "lazy %s not allowed inside try/except blocks", import_type);
+                     "lazy %s not allowed inside try/except blocks",
+                     import_type);
         SET_ERROR_LOCATION(st->st_filename, LOCATION(s));
         return 0;
     }
 
-    /* Check if inside function scope */
+    // Check if inside function scope.
     if (st->st_cur->ste_type == FunctionBlock) {
         PyErr_Format(PyExc_SyntaxError,
-                    "lazy %s not allowed inside functions", import_type);
+                     "lazy %s not allowed inside functions", import_type);
         SET_ERROR_LOCATION(st->st_filename, LOCATION(s));
         return 0;
     }
 
-    /* Check if inside class scope */
+    // Check if inside class scope.
     if (st->st_cur->ste_type == ClassBlock) {
         PyErr_Format(PyExc_SyntaxError,
-                    "lazy %s not allowed inside classes", import_type);
+                     "lazy %s not allowed inside classes", import_type);
         SET_ERROR_LOCATION(st->st_filename, LOCATION(s));
         return 0;
     }
@@ -2153,11 +2155,15 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
                 return 0;
             }
 
-            /* Check for import * */
-            for (Py_ssize_t i = 0; i < asdl_seq_LEN(s->v.ImportFrom.names); i++) {
-                alias_ty alias = (alias_ty)asdl_seq_GET(s->v.ImportFrom.names, i);
-                if (alias->name && _PyUnicode_EqualToASCIIString(alias->name, "*")) {
-                    PyErr_SetString(PyExc_SyntaxError, "lazy from ... import * is not allowed");
+            // Check for import *
+            for (Py_ssize_t i = 0; i < asdl_seq_LEN(s->v.ImportFrom.names);
+                 i++) {
+                alias_ty alias = (alias_ty)asdl_seq_GET(
+                    s->v.ImportFrom.names, i);
+                if (alias->name &&
+                        _PyUnicode_EqualToASCIIString(alias->name, "*")) {
+                    PyErr_SetString(PyExc_SyntaxError,
+                                    "lazy from ... import * is not allowed");
                     SET_ERROR_LOCATION(st->st_filename, LOCATION(s));
                     return 0;
                 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2855,7 +2855,8 @@ sys_set_lazy_imports_impl(PyObject *module, PyObject *mode)
 {
     PyImport_LazyImportsMode lazy_mode;
     if (!PyUnicode_Check(mode)) {
-        PyErr_SetString(PyExc_TypeError, "mode must be a string: 'normal', 'all', or 'none'");
+        PyErr_SetString(PyExc_TypeError,
+                        "mode must be a string: 'normal', 'all', or 'none'");
         return NULL;
     }
     if (PyUnicode_CompareWithASCIIString(mode, "normal") == 0) {
@@ -2868,7 +2869,8 @@ sys_set_lazy_imports_impl(PyObject *module, PyObject *mode)
         lazy_mode = PyImport_LAZY_NONE;
     }
     else {
-        PyErr_SetString(PyExc_ValueError, "mode must be 'normal', 'all', or 'none'");
+        PyErr_SetString(PyExc_ValueError,
+                        "mode must be 'normal', 'all', or 'none'");
         return NULL;
     }
 


### PR DESCRIPTION
Reflow and reformat to stick to PEP 7's line length limit in most places, and prefer using `//` for comments instead of `/* */`.
(There are still lines going over the limit for a variety of reasons, but this fixes all the reasonably fixable ones.)