### PR TITLE
Remove `get_lazy_modules` from docs

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -940,18 +940,6 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    .. versionadded:: next
 
 
-.. function:: get_lazy_modules()
-
-   Returns a set of fully-qualified module names that have been
-   lazily imported. This is primarily useful for diagnostics and
-   introspection.
-
-   Note that modules are removed from this set when they are reified
-   (actually loaded on first use).
-
-   .. versionadded:: next
-
-
 .. function:: getrefcount(object)
 
    Return the reference count of the *object*.  The count returned is generally one

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -164,11 +164,8 @@ eager:
    import myapp.slow_module  # lazy (matches filter)
    import json               # eager (does not match filter)
 
-For debugging and introspection, :func:`sys.get_lazy_modules` returns a set
-containing the names of all modules that have been lazily imported but not
-yet loaded. The proxy type itself is available as
-:data:`types.LazyImportType` for code that needs to detect lazy imports
-programmatically.
+The proxy type itself is available as :data:`types.LazyImportType` for code
+that needs to detect lazy imports programmatically.
 
 There are some restrictions on where the ``lazy`` keyword can be used. Lazy
 imports are only permitted at module scope; using ``lazy`` inside a


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Re: https://github.com/python/cpython/pull/142351#discussion_r2630932906

Code was removed in https://github.com/python/cpython/commit/4fd8fe8a833321374840d199f43acd5a32d1063d, also remove from the docs.