### PR TITLE
Clarify that lazy imports filter has positional parameters

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1783,7 +1783,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    signature::
 
       def filter(importing_module: str, imported_module: str,
-                 fromlist: tuple[str, ...] | None) -> bool
+                 fromlist: tuple[str, ...] | None, /) -> bool
 
    Where:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This fails:

```py
import sys

sys.set_lazy_imports_filter(lambda *, importing_module, imported_module, fromlist: True)

lazy import foobar
```
