### PR TITLE
Remove `types.LazyImportType` from pure variant of `types`

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -76,9 +76,8 @@ except ImportError:
     # CapsuleType cannot be accessed from pure Python,
     # so there is no fallback definition.
 
-    exec("lazy import sys as _lazy_sys", _lz := {})
-    LazyImportType = type(_lz['_lazy_sys'])
-    del _lz
+    # LazyImportType in pure Python cannot be guaranteed
+    # overriding global filter, so there is no fallback definition.
 
     del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -77,7 +77,7 @@ except ImportError:
     # so there is no fallback definition.
 
     # LazyImportType in pure Python cannot be guaranteed
-    # overriding global filter, so there is no fallback definition.
+    # without overriding the filter, so there is no fallback definition.
 
     del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -76,6 +76,7 @@ except ImportError:
     # CapsuleType cannot be accessed from pure Python,
     # so there is no fallback definition.
 
+    # LazyImportType in pure Python cannot be guaranteed
     # without overriding the filter, so there is no fallback.
 
     del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -76,8 +76,7 @@ except ImportError:
     # CapsuleType cannot be accessed from pure Python,
     # so there is no fallback definition.
 
-    # LazyImportType in pure Python cannot be guaranteed
-    # without overriding the filter, so there is no fallback definition.
+    # without overriding the filter, so there is no fallback.
 
     del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 


### PR DESCRIPTION
Closes #43.

Documentation tracked in #42.